### PR TITLE
Improve graph usability

### DIFF
--- a/frontend/src/GraphStage.css
+++ b/frontend/src/GraphStage.css
@@ -431,3 +431,29 @@
 .connected-item:hover {
   background: #333;
 }
+
+.minimap {
+  position: absolute;
+  bottom: 20px;
+  right: 20px;
+  border: 1px solid #333;
+  background: #000;
+  z-index: 5;
+  pointer-events: none;
+}
+
+.minimap-toggle {
+  background: #333;
+  color: #00ffff;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+  height: fit-content;
+  align-self: flex-end;
+}
+
+.minimap-toggle:hover {
+  background: #444;
+}


### PR DESCRIPTION
## Summary
- add layout and minimap state variables
- highlight nodes on hover and selection
- allow toggling minimap view and choose between force or timeline layout
- add minimap overlay and button styles

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687d91c2f0c0832cb57098f2f65fba72