### PR TITLE
feat: require project slug before upload

### DIFF
--- a/frontend/src/ComprehensiveShell.jsx
+++ b/frontend/src/ComprehensiveShell.jsx
@@ -57,6 +57,24 @@ export default function ComprehensiveShell() {
   async function handleFiles(selectedFiles, slug) {
     if (!selectedFiles.length) return;
 
+    if (!slug) {
+      setStatusMessage("Project slug is required.");
+      return;
+    }
+
+    try {
+      const res = await fetch("http://localhost:8000/projects");
+      const projects = await res.json();
+      if (!projects[slug]) {
+        setStatusMessage("Project slug not found.");
+        return;
+      }
+    } catch (err) {
+      console.error("Error validating slug", err);
+      setStatusMessage("Error validating project slug.");
+      return;
+    }
+
     setProjectSlug(slug);
     setStatusMessage("Processing files...");
 

--- a/frontend/src/UploadStage.css
+++ b/frontend/src/UploadStage.css
@@ -47,6 +47,30 @@ input[type="file"] {
   font-size: 0.9rem;
 }
 
+.slug-input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: transparent;
+  color: #ffffff;
+  margin-top: 1rem;
+}
+
+.slug-input.invalid {
+  border-color: var(--error);
+}
+
+.slug-error {
+  color: var(--error);
+  margin-top: 0.5rem;
+}
+
+.upload-area.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 .project-list {
   text-align: left;
   margin: 2rem 0;

--- a/frontend/src/UploadStage.jsx
+++ b/frontend/src/UploadStage.jsx
@@ -14,8 +14,15 @@ const TrashIcon = () => (
   </svg>
 );
 
-export default function UploadStage({ onFiles, statusMessage, onJump }) {
+export default function UploadStage({
+  onFiles,
+  statusMessage,
+  projectSlug,
+  setProjectSlug,
+  onJump,
+}) {
   const [projects, setProjects] = useState({});
+  const [slugValid, setSlugValid] = useState(false);
 
   useEffect(() => {
     fetch("http://localhost:8000/projects")
@@ -23,9 +30,17 @@ export default function UploadStage({ onFiles, statusMessage, onJump }) {
       .then(setProjects);
   }, []);
 
+  useEffect(() => {
+    if (projectSlug) {
+      setSlugValid(Object.prototype.hasOwnProperty.call(projects, projectSlug));
+    } else {
+      setSlugValid(false);
+    }
+  }, [projectSlug, projects]);
+
   function handleChange(e) {
     const files = Array.from(e.target.files || []);
-    if (files.length) onFiles(files);
+    if (files.length && slugValid) onFiles(files, projectSlug);
   }
 
   return (
@@ -42,7 +57,10 @@ export default function UploadStage({ onFiles, statusMessage, onJump }) {
                 <li key={name}>
                   <button
                     className="jump-link"
-                    onClick={() => onJump && onJump(name)}
+                    onClick={() => {
+                      setProjectSlug(name);
+                      if (onJump) onJump(name);
+                    }}
                   >
                     {name}
                   </button>
@@ -77,7 +95,21 @@ export default function UploadStage({ onFiles, statusMessage, onJump }) {
           </>
         )}
 
-        <label htmlFor="file-upload" className="upload-area">
+        <input
+          type="text"
+          value={projectSlug}
+          onChange={(e) => setProjectSlug(e.target.value)}
+          placeholder="Enter project slug"
+          className={`slug-input ${projectSlug && !slugValid ? "invalid" : ""}`}
+        />
+        {projectSlug && !slugValid && (
+          <p className="slug-error">Project slug not found</p>
+        )}
+
+        <label
+          htmlFor="file-upload"
+          className={`upload-area ${slugValid ? "" : "disabled"}`}
+        >
           Drop new PDFs here or click to select
         </label>
         <input
@@ -86,6 +118,7 @@ export default function UploadStage({ onFiles, statusMessage, onJump }) {
           multiple
           onChange={handleChange}
           id="file-upload"
+          disabled={!slugValid}
         />
 
         {statusMessage && (


### PR DESCRIPTION
## Summary
- add project slug input and validation in UploadStage
- check slug against `/projects` before processing files

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: existing lint errors)


------
https://chatgpt.com/codex/tasks/task_e_689111f1d5e4832c94d5d9f3467815d4