### PR TITLE
Send project_slug to quality guard endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -58,24 +58,28 @@ async def build_graph(request: Request):
 async def run_quality_validation(request: Request):
     """Run comprehensive quality validation"""
     filename = request.query_params.get("filename")
-    project_slug = request.query_params.get("project")
-    
+    project_slug = request.query_params.get("project_slug")
+
     if not filename or not project_slug:
-        raise HTTPException(status_code=400, detail="filename and project query params required")
+        raise HTTPException(status_code=400, detail="filename and project_slug query params required")
     
     # Load required data
     themes_path = f"/DropZone/{project_slug}/graphs/{filename.replace('.pdf', '_themes.json')}"
     atoms_path = f"/DropZone/{project_slug}/atoms/{filename.replace('.pdf', '_atoms.json')}"
     insights_path = f"/DropZone/{project_slug}/graphs/{filename.replace('.pdf', '_insights.json')}"
     board_path = f"/DropZone/{project_slug}/boards/{filename.replace('.pdf', '_board.json')}"
-    
+
     try:
+        print(f"Reading themes file: {themes_path}")
         with open(themes_path, 'r') as f:
             themes = json.load(f)
+        print(f"Reading atoms file: {atoms_path}")
         with open(atoms_path, 'r') as f:
             atoms = json.load(f)
+        print(f"Reading insights file: {insights_path}")
         with open(insights_path, 'r') as f:
             insights = json.load(f)
+        print(f"Reading board file: {board_path}")
         with open(board_path, 'r') as f:
             board_data = json.load(f)
     except FileNotFoundError as e:

--- a/frontend/src/QualityGuardStage.jsx
+++ b/frontend/src/QualityGuardStage.jsx
@@ -1,15 +1,12 @@
 import { useState, useEffect } from "react";
-import { useGlobalStore } from "./store";
 import "./QualityGuardStage.css";
 
-export default function QualityGuardStage({ file, context }) {
+export default function QualityGuardStage({ file }) {
   const [validationReport, setValidationReport] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [activeTab, setActiveTab] = useState('overview');
   
-  const selectedFile = useGlobalStore((state) => state.selectedFile);
-
   useEffect(() => {
     if (file && file.name) {
       runQualityValidation();
@@ -27,7 +24,7 @@ export default function QualityGuardStage({ file, context }) {
 
     try {
       const response = await fetch(
-        `http://localhost:8000/quality-guard?filename=${encodeURIComponent(file.name)}&project=${encodeURIComponent(file.project_slug)}`,
+        `http://localhost:8000/quality-guard?filename=${encodeURIComponent(file.name)}&project_slug=${encodeURIComponent(file.project_slug)}`,
         { method: "POST" }
       );
 


### PR DESCRIPTION
## Summary
- send project_slug when calling the quality guard endpoint
- require project_slug query param and log file paths on the backend quality-guard endpoint

## Testing
- `pytest` (no tests ran)
- `npm run lint` (fails: existing lint errors)


------
https://chatgpt.com/codex/tasks/task_e_689111f04884832ca931ff1f499409b5