### PR TITLE
Add basic board and human checkpoint stages

### DIFF
--- a/frontend/src/BoardStage.css
+++ b/frontend/src/BoardStage.css
@@ -1,0 +1,49 @@
+.board-stage {
+  padding: 1rem;
+  height: 100%;
+  overflow: auto;
+  color: #fff;
+}
+
+.board-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.board-link {
+  color: #00ffff;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.board-link:hover {
+  text-decoration: underline;
+}
+
+.board-content {
+  background: #111;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 1rem;
+  overflow: auto;
+}
+
+.board-json {
+  white-space: pre-wrap;
+  font-family: monospace;
+  color: #00ffff;
+  font-size: 0.85rem;
+}
+
+.empty-state {
+  text-align: center;
+  margin-top: 2rem;
+  color: #666;
+}
+
+.empty-icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/BoardStage.jsx
+++ b/frontend/src/BoardStage.jsx
@@ -1,0 +1,42 @@
+import "./BoardStage.css";
+
+export default function BoardStage({ file }) {
+  if (!file || !file.board) {
+    return (
+      <div className="board-stage">
+        <div className="empty-state">
+          <div className="empty-icon">🗂️</div>
+          <h2 className="empty-title">No board data</h2>
+          <p className="empty-text">Create a board to visualize themes and insights.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const board = file.board;
+
+  return (
+    <div className="board-stage">
+      <header className="board-header">
+        <h1 className="board-title">Research Board</h1>
+        {board.board_url && (
+          <a
+            href={board.board_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="board-link"
+          >
+            Open Collaborative Board ↗
+          </a>
+        )}
+      </header>
+
+      <div className="board-content">
+        <pre className="board-json">
+          {JSON.stringify(board, null, 2)}
+        </pre>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/HumanCheckpointsStage.css
+++ b/frontend/src/HumanCheckpointsStage.css
@@ -1,0 +1,60 @@
+.human-checkpoints-stage {
+  padding: 1rem;
+  color: #fff;
+  height: 100%;
+  overflow: auto;
+}
+
+.question-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.question-item {
+  background: #111;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 1rem;
+}
+
+.question-context {
+  font-size: 0.8rem;
+  color: #888;
+  margin-bottom: 0.5rem;
+}
+
+.question-text {
+  margin-bottom: 0.5rem;
+}
+
+.question-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.option-btn {
+  background: #222;
+  border: 1px solid #00ffff;
+  color: #00ffff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.option-btn.selected {
+  background: #00ffff;
+  color: #000;
+}
+
+.empty-state,
+.loading,
+.error {
+  text-align: center;
+  margin-top: 2rem;
+  color: #666;
+}

--- a/frontend/src/HumanCheckpointsStage.jsx
+++ b/frontend/src/HumanCheckpointsStage.jsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from "react";
+import "./HumanCheckpointsStage.css";
+
+export default function HumanCheckpointsStage({ file }) {
+  const [questions, setQuestions] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function fetchQuestions() {
+      if (!file || !file.project_slug) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(
+          `http://localhost:8000/qa?project=${encodeURIComponent(file.project_slug)}&filename=${encodeURIComponent(file.name)}`
+        );
+        if (!res.ok) throw new Error("Failed to load checkpoints");
+        const data = await res.json();
+        if (Array.isArray(data?.questions)) {
+          setQuestions(data.questions);
+        } else if (Array.isArray(data)) {
+          setQuestions(data);
+        } else {
+          setQuestions([]);
+        }
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchQuestions();
+  }, [file]);
+
+  async function answerQuestion(id, answer) {
+    setQuestions(prev => prev.map(q => q.question_id === id ? { ...q, current_answer: answer } : q));
+    try {
+      await fetch("http://localhost:8000/qa/answer", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          project: file.project_slug,
+          question_id: id,
+          answer
+        })
+      });
+    } catch {
+      // Ignore errors for now
+    }
+  }
+
+  if (!file) {
+    return (
+      <div className="human-checkpoints-stage">
+        <div className="empty-state">No file selected</div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="human-checkpoints-stage">
+        <div className="loading">Loading questions...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="human-checkpoints-stage">
+        <div className="error">Error: {error}</div>
+      </div>
+    );
+  }
+
+  if (!questions.length) {
+    return (
+      <div className="human-checkpoints-stage">
+        <div className="empty-state">No pending questions</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="human-checkpoints-stage">
+      <h1>Human Checkpoints</h1>
+      <ul className="question-list">
+        {questions.map(q => (
+          <li key={q.question_id} className="question-item">
+            {q.context && <div className="question-context">{q.context}</div>}
+            <div className="question-text">{q.question}</div>
+            <div className="question-options">
+              {q.options?.map(opt => (
+                <button
+                  key={opt}
+                  className={`option-btn ${q.current_answer === opt ? "selected" : ""}`}
+                  onClick={() => answerQuestion(q.question_id, opt)}
+                >
+                  {opt}
+                </button>
+              ))}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `BoardStage` to display board JSON and link to collaborative board
- add `HumanCheckpointsStage` to fetch and answer pending clarification questions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689111ef512c832cbe7ecef50ada8472