### PR TITLE
Add project slug support for comments

### DIFF
--- a/backend/dropzone.py
+++ b/backend/dropzone.py
@@ -27,10 +27,11 @@ class ProjectMetadata(BaseModel):
 
 class DropZoneManager:
     """Manages project-based DropZone system"""
-    
-    def __init__(self, base_path: str = "/DropZone"):
+
+    def __init__(self, project_slug: str = None, base_path: str = "/DropZone"):
         self.base_path = Path(base_path)
         self.base_path.mkdir(parents=True, exist_ok=True)
+        self.project_slug = project_slug
         self.projects_file = self.base_path / "projects.json"
         
     def create_project(self, name: str, description: str, researcher: str, 
@@ -88,6 +89,14 @@ class DropZoneManager:
     def get_project_path(self, project_slug: str, stage: str = "raw") -> Path:
         """Get path for specific project and stage"""
         return self.base_path / project_slug / stage
+
+    def get_path(self, stage: str, filename: str = "") -> Path:
+        """Get path within current project"""
+        if not self.project_slug:
+            raise ValueError("project_slug is required")
+        path = self.base_path / self.project_slug / stage
+        path.mkdir(parents=True, exist_ok=True)
+        return path / filename if filename else path
     
     def _generate_slug(self, name: str) -> str:
         """Generate URL-friendly slug from name"""

--- a/backend/routes/comments.py
+++ b/backend/routes/comments.py
@@ -1,4 +1,3 @@
-import os
 import json
 from datetime import datetime
 from typing import Dict, Optional, List
@@ -6,7 +5,7 @@ from typing import Dict, Optional, List
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from paths import COMMENTS_DIR
+from dropzone import DropZoneManager
 
 router = APIRouter()
 
@@ -32,57 +31,60 @@ class CommentResponse(BaseModel):
     message: Optional[str] = None
 
 
-os.makedirs(COMMENTS_DIR, exist_ok=True)
-
-
-def get_comments_file(filename: str) -> str:
+def get_comments_file(project_slug: str, filename: str):
     safe_filename = filename.replace("/", "_").replace("\\", "_")
-    return os.path.join(COMMENTS_DIR, f"{safe_filename}.json")
+    return DropZoneManager(project_slug).get_path('comments', f'{safe_filename}.json')
 
 
-def load_comments(filename: str) -> Dict:
-    comments_file = get_comments_file(filename)
-    if os.path.exists(comments_file):
+def load_comments(project_slug: str, filename: str) -> Dict:
+    comments_file = get_comments_file(project_slug, filename)
+    if comments_file.exists():
         with open(comments_file, "r") as f:
             return json.load(f)
     return {"comments": {}, "metadata": {"filename": filename, "created": datetime.now().isoformat()}}
 
 
-def save_comments(filename: str, comments_data: Dict) -> None:
-    comments_file = get_comments_file(filename)
+def save_comments(project_slug: str, filename: str, comments_data: Dict) -> None:
+    comments_file = get_comments_file(project_slug, filename)
     comments_data["metadata"]["updated"] = datetime.now().isoformat()
     with open(comments_file, "w") as f:
         json.dump(comments_data, f, indent=2)
 
 
 @router.get("/comments/{filename}")
-async def get_comments(filename: str):
+async def get_comments(filename: str, project_slug: str = None):
+    if not project_slug:
+        raise HTTPException(status_code=400, detail="project_slug query param required")
     try:
-        return load_comments(filename)
+        return load_comments(project_slug, filename)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to load comments: {str(e)}")
 
 
 @router.post("/comments/{filename}")
-async def add_comment(filename: str, request: CommentRequest) -> CommentResponse:
+async def add_comment(filename: str, request: CommentRequest, project_slug: str = None) -> CommentResponse:
+    if not project_slug:
+        raise HTTPException(status_code=400, detail="project_slug query param required")
     try:
-        comments_data = load_comments(filename)
+        comments_data = load_comments(project_slug, filename)
         exchange_id = str(request.exchangeId)
         if exchange_id not in comments_data["comments"]:
             comments_data["comments"][exchange_id] = []
         comment_dict = request.comment.dict()
         comment_dict["created"] = datetime.now().isoformat()
         comments_data["comments"][exchange_id].append(comment_dict)
-        save_comments(filename, comments_data)
+        save_comments(project_slug, filename, comments_data)
         return CommentResponse(success=True, message="Comment added successfully")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to save comment: {str(e)}")
 
 
 @router.delete("/comments/{filename}/{comment_id}")
-async def delete_comment(filename: str, comment_id: int) -> CommentResponse:
+async def delete_comment(filename: str, comment_id: int, project_slug: str = None) -> CommentResponse:
+    if not project_slug:
+        raise HTTPException(status_code=400, detail="project_slug query param required")
     try:
-        comments_data = load_comments(filename)
+        comments_data = load_comments(project_slug, filename)
         found = False
         for exchange_id, comments_list in comments_data["comments"].items():
             original_length = len(comments_list)
@@ -92,7 +94,7 @@ async def delete_comment(filename: str, comment_id: int) -> CommentResponse:
         if not found:
             raise HTTPException(status_code=404, detail="Comment not found")
         comments_data["comments"] = {k: v for k, v in comments_data["comments"].items() if v}
-        save_comments(filename, comments_data)
+        save_comments(project_slug, filename, comments_data)
         return CommentResponse(success=True, message="Comment deleted successfully")
     except HTTPException:
         raise
@@ -101,9 +103,11 @@ async def delete_comment(filename: str, comment_id: int) -> CommentResponse:
 
 
 @router.get("/comments/{filename}/export")
-async def export_comments(filename: str):
+async def export_comments(filename: str, project_slug: str = None):
+    if not project_slug:
+        raise HTTPException(status_code=400, detail="project_slug query param required")
     try:
-        comments_data = load_comments(filename)
+        comments_data = load_comments(project_slug, filename)
         synthesis_format = {
             "filename": filename,
             "total_comments": sum(len(comments) for comments in comments_data["comments"].values()),
@@ -131,5 +135,5 @@ async def export_comments(filename: str):
 
 
 @router.get("/synthesis/{filename}/comments")
-async def get_synthesis_comments(filename: str):
-    return await export_comments(filename)
+async def get_synthesis_comments(filename: str, project_slug: str = None):
+    return await export_comments(filename, project_slug)

--- a/frontend/src/TranscriptStage.jsx
+++ b/frontend/src/TranscriptStage.jsx
@@ -13,14 +13,14 @@ export default function TranscriptStage({ file }) {
 
   // Load existing comments when file changes
   useEffect(() => {
-    if (file?.name) {
+    if (file?.name && file?.project_slug) {
       loadComments();
     }
-  }, [file?.name]);
+  }, [file?.name, file?.project_slug]);
 
   const loadComments = async () => {
     try {
-      const response = await fetch(`http://localhost:8000/comments/${encodeURIComponent(file.name)}`);
+      const response = await fetch(`http://localhost:8000/comments/${encodeURIComponent(file.name)}?project_slug=${encodeURIComponent(file.project_slug)}`);
       if (response.ok) {
         const data = await response.json();
         setComments(data.comments || {});
@@ -33,7 +33,7 @@ export default function TranscriptStage({ file }) {
   const saveComment = async (comment, exchangeId) => {
     try {
       setIsLoading(true);
-      const response = await fetch(`http://localhost:8000/comments/${encodeURIComponent(file.name)}`, {
+      const response = await fetch(`http://localhost:8000/comments/${encodeURIComponent(file.name)}?project_slug=${encodeURIComponent(file.project_slug)}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -64,7 +64,7 @@ export default function TranscriptStage({ file }) {
 
   const removeComment = async (exchangeId, commentId) => {
     try {
-      const response = await fetch(`http://localhost:8000/comments/${encodeURIComponent(file.name)}/${commentId}`, {
+      const response = await fetch(`http://localhost:8000/comments/${encodeURIComponent(file.name)}/${commentId}?project_slug=${encodeURIComponent(file.project_slug)}`, {
         method: 'DELETE',
       });
       


### PR DESCRIPTION
## Summary
- scope comments API to project slugs and resolve storage paths through DropZoneManager
- allow DropZoneManager to be instantiated with a project slug and expose `get_path`
- send project slug with comment requests in TranscriptStage

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689111ec9288832c94fefc575a1f10b6