### PR TITLE
Add project slug state and propagate to fetch calls

### DIFF
--- a/frontend/src/ComprehensiveShell.jsx
+++ b/frontend/src/ComprehensiveShell.jsx
@@ -111,7 +111,7 @@ export default function ComprehensiveShell() {
 
         // Step 5: Create board
         setStatusMessage(`Creating board: ${filename} (${i+1}/${selectedFiles.length})`);
-        const boardRes = await fetch(`http://localhost:8000/board/create`, {
+        const boardRes = await fetch(`http://localhost:8000/board/create?project_slug=${encodeURIComponent(slug)}`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ atoms: annotated, themes: graph.themes, project_slug: slug, filename }),
@@ -119,17 +119,17 @@ export default function ComprehensiveShell() {
         if (!boardRes.ok) throw new Error(`Board creation failed: ${boardRes.statusText}`);
         const board = await boardRes.json();
 
-        updated.push({
-          name: filename,
-          cleaned,
-          atoms,
-          annotated,
-          graph,
-          board,
-          project_slug: slug,
-          status: 'complete'
-        });
-      } catch (error) {
+      updated.push({
+        name: filename,
+        cleaned,
+        atoms,
+        annotated,
+        graph,
+        board,
+        project_slug: slug,
+        status: 'complete'
+      });
+    } catch (error) {
         console.error(`Error processing ${selectedFiles[i]?.name}:`, error);
         updated.push({
           name: selectedFiles[i]?.name || 'unknown',
@@ -137,16 +137,6 @@ export default function ComprehensiveShell() {
           error: error.message
         });
       }
-
-      updated.push({ 
-        name: filename, 
-        cleaned, 
-        atoms, 
-        annotated, 
-        graph,
-        board,
-        project_slug: slug
-      });
     }
 
     const newFiles = [...files, ...updated];

--- a/frontend/src/GraphStage.jsx
+++ b/frontend/src/GraphStage.jsx
@@ -8,6 +8,7 @@ import "./GraphStage.css";
 export default function GraphStage({ file }) {
   const graphRef = useRef();
   const [selectedNode, setSelectedNode] = useState(null);
+  const projectSlug = useGlobalStore((state) => state.projectSlug);
   
   // Validate and format graph data
   const formatGraphData = (rawGraph) => {
@@ -82,7 +83,7 @@ export default function GraphStage({ file }) {
       console.log("Enhancing graph with LLM...", rawGraph.nodes.length, "nodes");
       
       // Send nodes to backend for LLM analysis
-      const response = await fetch('http://localhost:8000/enhance-graph', {
+      const response = await fetch(`http://localhost:8000/enhance-graph?project_slug=${projectSlug}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/frontend/src/QualityGuardStage.jsx
+++ b/frontend/src/QualityGuardStage.jsx
@@ -2,22 +2,22 @@ import { useState, useEffect } from "react";
 import { useGlobalStore } from "./store";
 import "./QualityGuardStage.css";
 
-export default function QualityGuardStage({ file, context }) {
+export default function QualityGuardStage({ file }) {
   const [validationReport, setValidationReport] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [activeTab, setActiveTab] = useState('overview');
   
-  const selectedFile = useGlobalStore((state) => state.selectedFile);
+  const projectSlug = useGlobalStore((state) => state.projectSlug);
 
   useEffect(() => {
     if (file && file.name) {
       runQualityValidation();
     }
-  }, [file]);
+  }, [file, projectSlug]);
 
   async function runQualityValidation() {
-    if (!file || !file.name || !file.project_slug) {
+    if (!file || !file.name || !projectSlug) {
       setError("No file selected or missing project information");
       return;
     }
@@ -27,7 +27,7 @@ export default function QualityGuardStage({ file, context }) {
 
     try {
       const response = await fetch(
-        `http://localhost:8000/quality-guard?filename=${encodeURIComponent(file.name)}&project=${encodeURIComponent(file.project_slug)}`,
+        `http://localhost:8000/quality-guard?filename=${encodeURIComponent(file.name)}&project_slug=${encodeURIComponent(projectSlug)}`,
         { method: "POST" }
       );
 

--- a/frontend/src/UploadStage.jsx
+++ b/frontend/src/UploadStage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useGlobalStore } from "./store";
 import "./UploadStage.css";
 
 const TrashIcon = () => (
@@ -16,16 +17,21 @@ const TrashIcon = () => (
 
 export default function UploadStage({ onFiles, statusMessage, onJump }) {
   const [projects, setProjects] = useState({});
+  const projectSlug = useGlobalStore((state) => state.projectSlug);
+  const setProjectSlug = useGlobalStore((state) => state.setProjectSlug);
 
   useEffect(() => {
-    fetch("http://localhost:8000/projects")
+    fetch(`http://localhost:8000/projects?project_slug=${projectSlug}`)
       .then((r) => r.json())
       .then(setProjects);
-  }, []);
+  }, [projectSlug]);
 
   function handleChange(e) {
     const files = Array.from(e.target.files || []);
-    if (files.length) onFiles(files);
+    if (files.length) {
+      setProjectSlug(files[0].name);
+      onFiles(files);
+    }
   }
 
   return (
@@ -42,7 +48,10 @@ export default function UploadStage({ onFiles, statusMessage, onJump }) {
                 <li key={name}>
                   <button
                     className="jump-link"
-                    onClick={() => onJump && onJump(name)}
+                    onClick={() => {
+                      setProjectSlug(name);
+                      onJump && onJump(name);
+                    }}
                   >
                     {name}
                   </button>
@@ -57,13 +66,13 @@ export default function UploadStage({ onFiles, statusMessage, onJump }) {
                     className="delete-btn"
                     onClick={async () => {
                       await fetch(
-                        `http://localhost:8000/projects/${encodeURIComponent(name)}`,
+                        `http://localhost:8000/projects/${encodeURIComponent(name)}?project_slug=${projectSlug}`,
                         {
                           method: "DELETE",
                         }
                       );
                       // refresh list
-                      fetch("http://localhost:8000/projects")
+                      fetch(`http://localhost:8000/projects?project_slug=${projectSlug}`)
                         .then((r) => r.json())
                         .then(setProjects);
                     }}

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -3,6 +3,8 @@ import { create } from "zustand";
 export const useGlobalStore = create((set) => ({
   selectedFile: null,
   graphData: {},
+  projectSlug: "",
+  setProjectSlug: (slug) => set({ projectSlug: slug }),
   setGraphData: (data) => set({ graphData: data }),
   setSelectedFile: (file) => set({ selectedFile: file }),
 }));


### PR DESCRIPTION
## Summary
- add `projectSlug` to global store
- include `project_slug` query parameter in all relevant fetch requests
- drop obsolete `project=` parameters

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689111ede9f0832c928bf612cd6b68e2