### PR TITLE
feat: centralize API calls with project-aware helper

### DIFF
--- a/frontend/src/GraphStage.jsx
+++ b/frontend/src/GraphStage.jsx
@@ -1,8 +1,8 @@
 // Fixed GraphStage.jsx with proper data validation
 
 import { useEffect, useRef, useState, useMemo } from "react";
+import { fetchWithProject } from "./api";
 import ForceGraph2D from "react-force-graph-2d";
-import { useGlobalStore } from "./store";
 import "./GraphStage.css";
 
 export default function GraphStage({ file }) {
@@ -82,7 +82,7 @@ export default function GraphStage({ file }) {
       console.log("Enhancing graph with LLM...", rawGraph.nodes.length, "nodes");
       
       // Send nodes to backend for LLM analysis
-      const response = await fetch('http://localhost:8000/enhance-graph', {
+      const response = await fetchWithProject('/enhance-graph', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -94,7 +94,7 @@ export default function GraphStage({ file }) {
             tags: node.tags || []
           }))
         })
-      });
+      }, file?.project_slug);
       
       if (!response.ok) {
         console.warn('LLM enhancement failed, using original data');

--- a/frontend/src/PipelineDashboard.jsx
+++ b/frontend/src/PipelineDashboard.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import "./PipelineDashboard.css";
+import { fetchWithProject } from "./api";
 import SynthesisDoc from "./SynthesisDoc";
 
 export default function PipelineDashboard({ files }) {
@@ -14,24 +15,24 @@ export default function PipelineDashboard({ files }) {
       const form = new FormData();
       files.forEach(f => form.append("files", f));
       setStatus({ upload: { state: "running" }, step: "upload" });
-      await fetch("http://localhost:8000/upload", { method: "POST", body: form });
+      await fetchWithProject("/upload", { method: "POST", body: form });
       setStatus(s => ({ ...s, upload: { state: "done" }, step: "upload" }));
 
       // 2. Normalize
       setStatus(s => ({ ...s, normalize: { state: "running" }, step: "normalize" }));
-      const normRes = await fetch("http://localhost:8000/normalize");
+      const normRes = await fetchWithProject("/normalize");
       const norm = await normRes.json();
       setStatus(s => ({ ...s, normalize: { state: "done", data: norm }, step: "normalize" }));
 
       // 3. Atomise
       setStatus(s => ({ ...s, atomise: { state: "running" }, step: "atomise" }));
-      const atomRes = await fetch("http://localhost:8000/atomise");
+      const atomRes = await fetchWithProject("/atomise");
       const atoms = await atomRes.json();
       setStatus(s => ({ ...s, atomise: { state: "done", data: atoms }, step: "atomise" }));
 
       // 4. Annotate
       setStatus(s => ({ ...s, annotate: { state: "running" }, step: "annotate" }));
-      const annRes = await fetch("http://localhost:8000/annotate", {
+      const annRes = await fetchWithProject("/annotate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(Object.values(atoms).flat().flat())

--- a/frontend/src/QualityGuardStage.jsx
+++ b/frontend/src/QualityGuardStage.jsx
@@ -1,14 +1,13 @@
 import { useState, useEffect } from "react";
-import { useGlobalStore } from "./store";
+import { fetchWithProject } from "./api";
 import "./QualityGuardStage.css";
 
-export default function QualityGuardStage({ file, context }) {
+export default function QualityGuardStage({ file }) {
   const [validationReport, setValidationReport] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [activeTab, setActiveTab] = useState('overview');
   
-  const selectedFile = useGlobalStore((state) => state.selectedFile);
 
   useEffect(() => {
     if (file && file.name) {
@@ -26,10 +25,7 @@ export default function QualityGuardStage({ file, context }) {
     setError(null);
 
     try {
-      const response = await fetch(
-        `http://localhost:8000/quality-guard?filename=${encodeURIComponent(file.name)}&project=${encodeURIComponent(file.project_slug)}`,
-        { method: "POST" }
-      );
+      const response = await fetchWithProject(`/quality-guard?filename=${encodeURIComponent(file.name)}`, { method: "POST" }, file.project_slug);
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);

--- a/frontend/src/UploadStage.jsx
+++ b/frontend/src/UploadStage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { fetchWithProject } from "./api";
 import "./UploadStage.css";
 
 const TrashIcon = () => (
@@ -18,7 +19,7 @@ export default function UploadStage({ onFiles, statusMessage, onJump }) {
   const [projects, setProjects] = useState({});
 
   useEffect(() => {
-    fetch("http://localhost:8000/projects")
+    fetchWithProject("/projects")
       .then((r) => r.json())
       .then(setProjects);
   }, []);
@@ -56,14 +57,14 @@ export default function UploadStage({ onFiles, statusMessage, onJump }) {
                   <button
                     className="delete-btn"
                     onClick={async () => {
-                      await fetch(
-                        `http://localhost:8000/projects/${encodeURIComponent(name)}`,
+                      await fetchWithProject(
+                        `/projects/${encodeURIComponent(name)}`,
                         {
                           method: "DELETE",
                         }
                       );
                       // refresh list
-                      fetch("http://localhost:8000/projects")
+                      fetchWithProject("/projects")
                         .then((r) => r.json())
                         .then(setProjects);
                     }}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,11 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
+
+export function fetchWithProject(path, options = {}, projectSlug) {
+  const url = new URL(path, API_BASE_URL);
+  if (projectSlug) {
+    url.searchParams.set('project_slug', projectSlug);
+  }
+  return fetch(url.toString(), options);
+}
+
+export { API_BASE_URL };


### PR DESCRIPTION
## Summary
- add API utility exposing `fetchWithProject` with env-configurable base URL
- refactor stage components to use `fetchWithProject`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689111f0d1ac832c86b630543ac59740