### PR TITLE
Use global store for project slug

### DIFF
--- a/frontend/src/ComprehensiveShell.jsx
+++ b/frontend/src/ComprehensiveShell.jsx
@@ -32,10 +32,8 @@ export default function ComprehensiveShell() {
   const [files, setFiles] = useState([]);
   const [activeFileIndex, setActiveFileIndex] = useState(null);
   const [statusMessage, setStatusMessage] = useState("");
-  const [projectSlug, setProjectSlug] = useState("");
   const [currentContext, setCurrentContext] = useState({});
-  
-  const setSelectedFile = useGlobalStore((state) => state.setSelectedFile);
+  const { projectSlug, setProjectSlug, setSelectedFile } = useGlobalStore((state) => state);
 
   // Context for chat assistant and quality guard
   const updateContext = useCallback(() => {
@@ -279,14 +277,12 @@ export default function ComprehensiveShell() {
       </nav>
 
       <main className="stage-content">
-        {stage === STAGES.UPLOAD && (
-          <UploadStage
-            onFiles={handleFiles}
-            statusMessage={statusMessage}
-            projectSlug={projectSlug}
-            setProjectSlug={setProjectSlug}
-          />
-        )}
+          {stage === STAGES.UPLOAD && (
+            <UploadStage
+              onFiles={handleFiles}
+              statusMessage={statusMessage}
+            />
+          )}
 
         {stage === STAGES.TRANSCRIPT && (
           <TranscriptStage 

--- a/frontend/src/QualityGuardStage.jsx
+++ b/frontend/src/QualityGuardStage.jsx
@@ -1,31 +1,37 @@
 import { useState, useEffect } from "react";
 import { fetchWithProject } from "./api";
 import "./QualityGuardStage.css";
+import { useGlobalStore } from "./store";
 
 export default function QualityGuardStage({ file }) {
   const [validationReport, setValidationReport] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [activeTab, setActiveTab] = useState('overview');
+  const projectSlug = useGlobalStore((state) => state.projectSlug);
   
 
   useEffect(() => {
     if (file && file.name) {
       runQualityValidation();
     }
-  }, [file]);
+  }, [file, projectSlug]);
 
-  async function runQualityValidation() {
-    if (!file || !file.name || !file.project_slug) {
-      setError("No file selected or missing project information");
-      return;
-    }
+    async function runQualityValidation() {
+      if (!file || !file.name || !projectSlug) {
+        setError("No file selected or missing project information");
+        return;
+      }
 
-    setLoading(true);
-    setError(null);
+      setLoading(true);
+      setError(null);
 
-    try {
-      const response = await fetchWithProject(`/quality-guard?filename=${encodeURIComponent(file.name)}`, { method: "POST" }, file.project_slug);
+      try {
+        const response = await fetchWithProject(
+          `/quality-guard?filename=${encodeURIComponent(file.name)}`,
+          { method: "POST" },
+          projectSlug
+        );
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);

--- a/frontend/src/UploadStage.jsx
+++ b/frontend/src/UploadStage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useGlobalStore } from "./store";
 import { fetchWithProject } from "./api";
 import "./UploadStage.css";
 
@@ -18,10 +19,12 @@ const TrashIcon = () => (
 export default function UploadStage({
   onFiles,
   statusMessage,
-  projectSlug,
-  setProjectSlug,
   onJump,
 }) {
+  const { projectSlug, setProjectSlug } = useGlobalStore((state) => ({
+    projectSlug: state.projectSlug,
+    setProjectSlug: state.setProjectSlug,
+  }));
   const [projects, setProjects] = useState({});
   const [slugValid, setSlugValid] = useState(false);
 

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -3,6 +3,8 @@ import { create } from "zustand";
 export const useGlobalStore = create((set) => ({
   selectedFile: null,
   graphData: {},
+  projectSlug: "",
   setGraphData: (data) => set({ graphData: data }),
   setSelectedFile: (file) => set({ selectedFile: file }),
+  setProjectSlug: (slug) => set({ projectSlug: slug }),
 }));


### PR DESCRIPTION
## Summary
- manage project slug in global store
- refactor components to read slug from store
- ensure API requests use stored slug

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689118e5be98832c980a4268593ec877