### PR TITLE
Ensure project slug passed with fetch calls

### DIFF
--- a/frontend/src/ComprehensiveShell.jsx
+++ b/frontend/src/ComprehensiveShell.jsx
@@ -64,7 +64,7 @@ export default function ComprehensiveShell() {
     }
 
     try {
-      const res = await fetch("http://localhost:8000/projects");
+      const res = await fetchWithProject("/projects", {}, slug);
       const projects = await res.json();
       if (!projects[slug]) {
         setStatusMessage("Project slug not found.");

--- a/frontend/src/HumanCheckpointsStage.jsx
+++ b/frontend/src/HumanCheckpointsStage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { fetchWithProject } from "./api";
 import "./HumanCheckpointsStage.css";
 
 export default function HumanCheckpointsStage({ file }) {
@@ -12,8 +13,10 @@ export default function HumanCheckpointsStage({ file }) {
       setLoading(true);
       setError(null);
       try {
-        const res = await fetch(
-          `http://localhost:8000/qa?project=${encodeURIComponent(file.project_slug)}&filename=${encodeURIComponent(file.name)}`
+        const res = await fetchWithProject(
+          `/qa?filename=${encodeURIComponent(file.name)}`,
+          {},
+          file.project_slug
         );
         if (!res.ok) throw new Error("Failed to load checkpoints");
         const data = await res.json();
@@ -36,15 +39,18 @@ export default function HumanCheckpointsStage({ file }) {
   async function answerQuestion(id, answer) {
     setQuestions(prev => prev.map(q => q.question_id === id ? { ...q, current_answer: answer } : q));
     try {
-      await fetch("http://localhost:8000/qa/answer", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          project: file.project_slug,
-          question_id: id,
-          answer
-        })
-      });
+      await fetchWithProject(
+        "/qa/answer",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            question_id: id,
+            answer
+          })
+        },
+        file.project_slug
+      );
     } catch {
       // Ignore errors for now
     }

--- a/frontend/src/PipelineDashboard.jsx
+++ b/frontend/src/PipelineDashboard.jsx
@@ -3,7 +3,7 @@ import "./PipelineDashboard.css";
 import { fetchWithProject } from "./api";
 import SynthesisDoc from "./SynthesisDoc";
 
-export default function PipelineDashboard({ files }) {
+export default function PipelineDashboard({ files, projectSlug }) {
   const [status, setStatus] = useState({}); // { step, state, data }
   const [expanded, setExpanded] = useState(null);
 
@@ -15,18 +15,18 @@ export default function PipelineDashboard({ files }) {
       const form = new FormData();
       files.forEach(f => form.append("files", f));
       setStatus({ upload: { state: "running" }, step: "upload" });
-      await fetchWithProject("/upload", { method: "POST", body: form });
+      await fetchWithProject("/upload", { method: "POST", body: form }, projectSlug);
       setStatus(s => ({ ...s, upload: { state: "done" }, step: "upload" }));
 
       // 2. Normalize
       setStatus(s => ({ ...s, normalize: { state: "running" }, step: "normalize" }));
-      const normRes = await fetchWithProject("/normalize");
+      const normRes = await fetchWithProject("/normalize", {}, projectSlug);
       const norm = await normRes.json();
       setStatus(s => ({ ...s, normalize: { state: "done", data: norm }, step: "normalize" }));
 
       // 3. Atomise
       setStatus(s => ({ ...s, atomise: { state: "running" }, step: "atomise" }));
-      const atomRes = await fetchWithProject("/atomise");
+      const atomRes = await fetchWithProject("/atomise", {}, projectSlug);
       const atoms = await atomRes.json();
       setStatus(s => ({ ...s, atomise: { state: "done", data: atoms }, step: "atomise" }));
 
@@ -36,7 +36,7 @@ export default function PipelineDashboard({ files }) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(Object.values(atoms).flat().flat())
-      });
+      }, projectSlug);
       const annotated = await annRes.json();
       setStatus(s => ({ ...s, annotate: { state: "done", data: annotated }, step: "annotate" }));
     })();

--- a/frontend/src/UploadStage.jsx
+++ b/frontend/src/UploadStage.jsx
@@ -26,10 +26,10 @@ export default function UploadStage({
   const [slugValid, setSlugValid] = useState(false);
 
   useEffect(() => {
-    fetchWithProject("/projects")
+    fetchWithProject("/projects", {}, projectSlug)
       .then((r) => r.json())
       .then(setProjects);
-  }, []);
+  }, [projectSlug]);
 
   useEffect(() => {
     if (projectSlug) {
@@ -79,10 +79,11 @@ export default function UploadStage({
                         `/projects/${encodeURIComponent(name)}`,
                         {
                           method: "DELETE",
-                        }
+                        },
+                        projectSlug
                       );
                       // refresh list
-                      fetchWithProject("/projects")
+                      fetchWithProject("/projects", {}, projectSlug)
                         .then((r) => r.json())
                         .then(setProjects);
                     }}


### PR DESCRIPTION
## Summary
- append `project_slug` query param to all frontend fetch calls
- remove obsolete `project` parameter in human checkpoints requests
- support project selection throughout pipeline components

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689118e51294832cae537ee232bdc2e8