### PR TITLE
refactor: use theme variables for stage colors

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -38,14 +38,14 @@
 }
 
 .read-the-docs {
-  color: #888;
+  color: var(--muted);
 }
 
 .drop-zone {
   height: 300px;
   width: 100%;
   max-width: 600px;
-  border: 2px dashed #999;
+  border: 2px dashed var(--border);
   border-radius: 8px;
   margin: 100px auto;
   display: flex;
@@ -53,5 +53,5 @@
   justify-content: center;
   align-items: center;
   font-family: sans-serif;
-  color: #fff;
+  color: var(--text);
 }

--- a/frontend/src/BoardStage.css
+++ b/frontend/src/BoardStage.css
@@ -2,7 +2,7 @@
   padding: 1rem;
   height: 100%;
   overflow: auto;
-  color: #fff;
+  color: var(--text);
 }
 
 .board-header {
@@ -13,7 +13,7 @@
 }
 
 .board-link {
-  color: #00ffff;
+  color: var(--accent);
   text-decoration: none;
   font-size: 0.9rem;
 }
@@ -23,8 +23,8 @@
 }
 
 .board-content {
-  background: #111;
-  border: 1px solid #333;
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 4px;
   padding: 1rem;
   overflow: auto;
@@ -33,14 +33,14 @@
 .board-json {
   white-space: pre-wrap;
   font-family: monospace;
-  color: #00ffff;
+  color: var(--accent);
   font-size: 0.85rem;
 }
 
 .empty-state {
   text-align: center;
   margin-top: 2rem;
-  color: #666;
+  color: var(--muted);
 }
 
 .empty-icon {

--- a/frontend/src/ChatAssistantStage.css
+++ b/frontend/src/ChatAssistantStage.css
@@ -4,18 +4,18 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
-  background: #f8f9fa;
+  background: var(--bg);
 }
 
 .stage-header {
   padding: 20px;
-  background: white;
-  border-bottom: 1px solid #dee2e6;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
 }
 
 .stage-header h1 {
   margin: 0;
-  color: #2c3e50;
+  color: var(--text);
 }
 
 .assistant-info {
@@ -26,8 +26,8 @@
 }
 
 .context-toggle {
-  background: #007bff;
-  color: white;
+  background: var(--accent);
+  color: var(--bg);
   border: none;
   padding: 8px 16px;
   border-radius: 4px;
@@ -36,7 +36,7 @@
 }
 
 .context-toggle:hover {
-  background: #0056b3;
+  background: var(--accent);
 }
 
 .chat-container {
@@ -52,7 +52,7 @@
   flex: 1;
   overflow-y: auto;
   padding: 20px;
-  background: white;
+  background: var(--surface);
 }
 
 .message {
@@ -79,18 +79,18 @@
 }
 
 .message.user .message-content {
-  background: #007bff;
-  color: white;
+  background: var(--accent);
+  color: var(--bg);
 }
 
 .message.assistant .message-content {
-  background: #e9ecef;
-  color: #2c3e50;
+  background: var(--surface);
+  color: var(--text);
 }
 
 .message-timestamp {
   font-size: 12px;
-  color: #6c757d;
+  color: var(--muted);
   margin-top: 5px;
 }
 
@@ -105,8 +105,8 @@
 }
 
 .action-button {
-  background: #28a745;
-  color: white;
+  background: var(--accent);
+  color: var(--bg);
   border: none;
   padding: 6px 12px;
   border-radius: 4px;
@@ -115,13 +115,13 @@
 }
 
 .action-button:hover {
-  background: #1e7e34;
+  background: var(--accent);
 }
 
 .chat-input-container {
   padding: 20px;
-  background: white;
-  border-top: 1px solid #dee2e6;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
 }
 
 .chat-input {
@@ -132,7 +132,7 @@
 .chat-input textarea {
   flex: 1;
   padding: 12px;
-  border: 1px solid #ced4da;
+  border: 1px solid var(--border);
   border-radius: 4px;
   resize: vertical;
   min-height: 60px;
@@ -142,12 +142,12 @@
 
 .chat-input textarea:focus {
   outline: none;
-  border-color: #007bff;
+  border-color: var(--accent);
 }
 
 .send-button {
-  background: #007bff;
-  color: white;
+  background: var(--accent);
+  color: var(--bg);
   border: none;
   padding: 12px 20px;
   border-radius: 4px;
@@ -156,39 +156,39 @@
 }
 
 .send-button:hover:not(:disabled) {
-  background: #0056b3;
+  background: var(--accent);
 }
 
 .send-button:disabled {
-  background: #6c757d;
+  background: var(--muted);
   cursor: not-allowed;
 }
 
 .loading {
   text-align: center;
   padding: 20px;
-  color: #6c757d;
+  color: var(--muted);
 }
 
 .error {
-  background: #f8d7da;
-  color: #721c24;
+  background: color-mix(in srgb, var(--error) 15%, var(--surface));
+  color: var(--error);
   padding: 15px;
   border-radius: 4px;
   margin: 10px 0;
-  border: 1px solid #f5c6cb;
+  border: 1px solid var(--error);
 }
 
 .quick-suggestions {
   padding: 15px;
-  background: #f8f9fa;
+  background: var(--surface);
   border-radius: 4px;
   margin-bottom: 15px;
 }
 
 .quick-suggestions h4 {
   margin: 0 0 10px 0;
-  color: #495057;
+  color: var(--text);
 }
 
 .suggestion-buttons {
@@ -198,8 +198,8 @@
 }
 
 .suggestion-button {
-  background: #e9ecef;
-  border: 1px solid #ced4da;
+  background: var(--surface);
+  border: 1px solid var(--border);
   padding: 6px 12px;
   border-radius: 16px;
   font-size: 12px;
@@ -207,7 +207,7 @@
 }
 
 .suggestion-button:hover {
-  background: #dee2e6;
+  background: var(--surface);
 }
 
 .context-panel {
@@ -216,8 +216,8 @@
   right: 0;
   width: 300px;
   height: 100vh;
-  background: white;
-  border-left: 1px solid #dee2e6;
+  background: var(--surface);
+  border-left: 1px solid var(--border);
   padding: 20px;
   overflow-y: auto;
   transform: translateX(100%);
@@ -230,23 +230,23 @@
 
 .context-panel h3 {
   margin-top: 0;
-  color: #2c3e50;
+  color: var(--text);
 }
 
 .context-item {
   margin: 10px 0;
   padding: 10px;
-  background: #f8f9fa;
+  background: var(--surface);
   border-radius: 4px;
 }
 
 .context-item h4 {
   margin: 0 0 5px 0;
-  color: #495057;
+  color: var(--text);
 }
 
 .context-item p {
   margin: 0;
   font-size: 14px;
-  color: #6c757d;
+  color: var(--muted);
 }

--- a/frontend/src/GraphStage.css
+++ b/frontend/src/GraphStage.css
@@ -91,7 +91,7 @@
 .graph-container {
   flex: 1;
   position: relative;
-  background: #0a0a0a;
+  background: var(--bg);
   overflow: hidden;
   pointer-events: auto; /* Ensure graph can receive events */
 }
@@ -179,18 +179,18 @@
 }
 
 .sentiment-positive {
-  background: rgba(16, 185, 129, 0.2);
-  color: #10b981;
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+  color: var(--accent);
 }
 
 .sentiment-negative {
-  background: rgba(239, 68, 68, 0.2);
-  color: #ef4444;
+  background: color-mix(in srgb, var(--error) 20%, transparent);
+  color: var(--error);
 }
 
 .sentiment-neutral {
-  background: rgba(107, 114, 128, 0.2);
-  color: #6b7280;
+  background: color-mix(in srgb, var(--muted) 20%, transparent);
+  color: var(--muted);
 }
 
 .node-text {
@@ -343,8 +343,8 @@
   top: 80px;
   right: 20px;
   width: 300px;
-  background: #1a1a1a;
-  border: 1px solid #333;
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 8px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
   z-index: 100;
@@ -357,11 +357,11 @@
   justify-content: space-between;
   align-items: center;
   padding: 1rem;
-  border-bottom: 1px solid #333;
+  border-bottom: 1px solid var(--border);
 }
 
 .panel-header h3 {
-  color: #00ffff;
+  color: var(--accent);
   margin: 0;
   font-size: 1rem;
 }
@@ -369,7 +369,7 @@
 .close-btn {
   background: none;
   border: none;
-  color: #666;
+  color: var(--muted);
   font-size: 1.5rem;
   cursor: pointer;
   padding: 0;
@@ -381,7 +381,7 @@
 }
 
 .close-btn:hover {
-  color: #fff;
+  color: var(--text);
 }
 
 .panel-content {
@@ -389,7 +389,7 @@
 }
 
 .main-text {
-  color: #fff;
+  color: var(--text);
   font-size: 0.9rem;
   line-height: 1.4;
   margin-bottom: 1rem;
@@ -405,12 +405,12 @@
   font-size: 0.75rem;
   padding: 0.25rem 0.5rem;
   border-radius: 4px;
-  background: #333;
-  color: #ccc;
+  background: var(--surface);
+  color: var(--muted);
 }
 
 .connections h4 {
-  color: #00ffff;
+  color: var(--accent);
   font-size: 0.8rem;
   margin: 0 0 0.5rem 0;
   text-transform: uppercase;
@@ -419,9 +419,9 @@
 
 .connected-item {
   font-size: 0.8rem;
-  color: #bbb;
+  color: var(--muted);
   padding: 0.5rem;
-  background: #222;
+  background: var(--surface);
   border-radius: 4px;
   margin-bottom: 0.5rem;
   cursor: pointer;
@@ -429,23 +429,23 @@
 }
 
 .connected-item:hover {
-  background: #333;
+  background: var(--surface);
 }
 
 .minimap {
   position: absolute;
   bottom: 20px;
   right: 20px;
-  border: 1px solid #333;
-  background: #000;
+  border: 1px solid var(--border);
+  background: var(--bg);
   z-index: 5;
   pointer-events: none;
 }
 
 .minimap-toggle {
-  background: #333;
-  color: #00ffff;
-  border: 1px solid #555;
+  background: var(--surface);
+  color: var(--accent);
+  border: 1px solid var(--border);
   border-radius: 4px;
   padding: 0.25rem 0.5rem;
   cursor: pointer;
@@ -455,5 +455,5 @@
 }
 
 .minimap-toggle:hover {
-  background: #444;
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
 }

--- a/frontend/src/HumanCheckpointsStage.css
+++ b/frontend/src/HumanCheckpointsStage.css
@@ -1,6 +1,6 @@
 .human-checkpoints-stage {
   padding: 1rem;
-  color: #fff;
+  color: var(--text);
   height: 100%;
   overflow: auto;
 }
@@ -14,15 +14,15 @@
 }
 
 .question-item {
-  background: #111;
-  border: 1px solid #333;
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 4px;
   padding: 1rem;
 }
 
 .question-context {
   font-size: 0.8rem;
-  color: #888;
+  color: var(--muted);
   margin-bottom: 0.5rem;
 }
 
@@ -37,9 +37,9 @@
 }
 
 .option-btn {
-  background: #222;
-  border: 1px solid #00ffff;
-  color: #00ffff;
+  background: var(--surface);
+  border: 1px solid var(--accent);
+  color: var(--accent);
   padding: 0.25rem 0.5rem;
   border-radius: 3px;
   cursor: pointer;
@@ -47,8 +47,8 @@
 }
 
 .option-btn.selected {
-  background: #00ffff;
-  color: #000;
+  background: var(--accent);
+  color: var(--bg);
 }
 
 .empty-state,
@@ -56,5 +56,5 @@
 .error {
   text-align: center;
   margin-top: 2rem;
-  color: #666;
+  color: var(--muted);
 }

--- a/frontend/src/PipelineDashboard.css
+++ b/frontend/src/PipelineDashboard.css
@@ -2,8 +2,8 @@
   max-width: 720px;
   margin: 2rem auto;
   font-family: "Inter", system-ui, sans-serif;
-  background: #111;
-  color: #e5e5e5;
+  background: var(--surface);
+  color: var(--text);
   padding: 2rem;
   border-radius: 12px;
 }
@@ -14,12 +14,12 @@
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: #9ca3af;
+  color: var(--muted);
 }
 
 .card {
-  background: #18181b;
-  border: 1px solid #27272a;
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 8px;
   margin-bottom: 0.75rem;
   overflow: hidden;
@@ -35,7 +35,7 @@
 }
 
 .card header:hover {
-  background: #27272a;
+  background: var(--surface);
 }
 
 .icon {
@@ -45,10 +45,10 @@
   flex-shrink: 0;
 }
 
-.icon.done   { color: #22c55e; }
-.icon.running{ color: #f59e0b; animation: spin 1.5s linear infinite; }
-.icon.error  { color: #ef4444; }
-.icon.idle   { color: #52525b; }
+.icon.done   { color: var(--accent); }
+.icon.running{ color: var(--accent); animation: spin 1.5s linear infinite; }
+.icon.error  { color: var(--error); }
+.icon.idle   { color: var(--muted); }
 
 @keyframes spin {
   from { transform: rotate(0deg); }
@@ -58,7 +58,7 @@
 .chevron {
   margin-left: auto;
   font-size: 0.7rem;
-  color: #71717a;
+  color: var(--muted);
 }
 
 pre {
@@ -66,7 +66,7 @@ pre {
   padding: 1rem;
   font-size: 0.75rem;
   line-height: 1.4;
-  background: #0a0a0a;
+  background: var(--bg);
   max-height: 320px;
   overflow: auto;
 }

--- a/frontend/src/QualityGuardStage.css
+++ b/frontend/src/QualityGuardStage.css
@@ -11,32 +11,32 @@
 }
 
 .stage-header h1 {
-  color: #2c3e50;
+  color: var(--text);
   margin-bottom: 10px;
 }
 
 .stage-description {
-  color: #7f8c8d;
+  color: var(--muted);
   font-size: 16px;
 }
 
 .loading {
   text-align: center;
   padding: 40px;
-  color: #7f8c8d;
+  color: var(--muted);
 }
 
 .error {
-  background: #fee;
-  border: 1px solid #fcc;
+  background: color-mix(in srgb, var(--error) 15%, var(--surface));
+  border: 1px solid var(--error);
   border-radius: 8px;
   padding: 20px;
   margin: 20px 0;
-  color: #c33;
+  color: var(--error);
 }
 
 .validation-report {
-  background: white;
+  background: var(--surface);
   border-radius: 8px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   overflow: hidden;
@@ -44,8 +44,8 @@
 
 .tabs {
   display: flex;
-  background: #f8f9fa;
-  border-bottom: 1px solid #dee2e6;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
 }
 
 .tab {
@@ -54,14 +54,14 @@
   border: none;
   background: none;
   font-size: 14px;
-  color: #6c757d;
+  color: var(--muted);
   transition: all 0.3s ease;
 }
 
 .tab.active {
-  color: #007bff;
-  border-bottom: 2px solid #007bff;
-  background: white;
+  color: var(--accent);
+  border-bottom: 2px solid var(--accent);
+  background: var(--surface);
 }
 
 .tab-content {
@@ -75,7 +75,7 @@
 .score-display {
   text-align: center;
   padding: 20px;
-  background: #f8f9fa;
+  background: var(--surface);
   border-radius: 8px;
   margin-bottom: 20px;
 }
@@ -83,12 +83,12 @@
 .score-number {
   font-size: 48px;
   font-weight: bold;
-  color: #28a745;
+  color: var(--accent);
 }
 
 .score-label {
   font-size: 14px;
-  color: #6c757d;
+  color: var(--muted);
   margin-top: 5px;
 }
 
@@ -99,24 +99,24 @@
 .issue-item {
   padding: 15px;
   margin: 10px 0;
-  border-left: 4px solid #ddd;
-  background: #f8f9fa;
+  border-left: 4px solid var(--border);
+  background: var(--surface);
   border-radius: 4px;
 }
 
 .issue-item.critical {
-  border-left-color: #dc3545;
-  background: #f8d7da;
+  border-left-color: var(--error);
+  background: color-mix(in srgb, var(--error) 15%, var(--surface));
 }
 
 .issue-item.warning {
-  border-left-color: #ffc107;
-  background: #fff3cd;
+  border-left-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 15%, var(--surface));
 }
 
 .issue-item.info {
-  border-left-color: #17a2b8;
-  background: #d1ecf1;
+  border-left-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, var(--surface));
 }
 
 .issue-title {
@@ -126,12 +126,12 @@
 
 .issue-description {
   font-size: 14px;
-  color: #6c757d;
+  color: var(--muted);
 }
 
 .issue-recommendation {
   font-size: 13px;
-  color: #495057;
+  color: var(--muted);
   margin-top: 8px;
   font-style: italic;
 }
@@ -143,7 +143,7 @@
 .evidence-item {
   padding: 10px;
   margin: 5px 0;
-  background: #f8f9fa;
+  background: var(--surface);
   border-radius: 4px;
   font-size: 14px;
 }
@@ -156,7 +156,7 @@
 }
 
 .metric-card {
-  background: #f8f9fa;
+  background: var(--surface);
   padding: 20px;
   border-radius: 8px;
   text-align: center;
@@ -165,12 +165,12 @@
 .metric-value {
   font-size: 24px;
   font-weight: bold;
-  color: #007bff;
+  color: var(--accent);
 }
 
 .metric-label {
   font-size: 14px;
-  color: #6c757d;
+  color: var(--muted);
   margin-top: 5px;
 }
 
@@ -181,23 +181,23 @@
 .recommendation-item {
   padding: 15px;
   margin: 10px 0;
-  background: #e8f5e8;
-  border-left: 4px solid #28a745;
+  background: color-mix(in srgb, var(--accent) 15%, var(--surface));
+  border-left: 4px solid var(--accent);
   border-radius: 4px;
 }
 
 .recommendation-title {
   font-weight: bold;
-  color: #155724;
+  color: var(--accent);
 }
 
 .recommendation-description {
   margin-top: 5px;
-  color: #155724;
+  color: var(--text);
 }
 
 .summary-section {
-  background: #f8f9fa;
+  background: var(--surface);
   padding: 20px;
   border-radius: 8px;
   margin: 20px 0;
@@ -207,7 +207,7 @@
   display: flex;
   justify-content: space-between;
   padding: 8px 0;
-  border-bottom: 1px solid #dee2e6;
+  border-bottom: 1px solid var(--border);
 }
 
 .summary-item:last-child {
@@ -219,21 +219,21 @@
 }
 
 .summary-value {
-  color: #007bff;
+  color: var(--accent);
 }
 
 .empty-state {
   text-align: center;
   padding: 40px;
-  color: #6c757d;
+  color: var(--muted);
 }
 
 .loading-spinner {
   display: inline-block;
   width: 20px;
   height: 20px;
-  border: 3px solid #f3f3f3;
-  border-top: 3px solid #007bff;
+  border: 3px solid var(--border);
+  border-top: 3px solid var(--accent);
   border-radius: 50%;
   animation: spin 1s linear infinite;
 }

--- a/frontend/src/Sidebar.css
+++ b/frontend/src/Sidebar.css
@@ -2,8 +2,8 @@
 .sidebar {
   width: 220px;
   padding: 1rem;
-  background: #f5f5f5;
-  border-right: 1px solid #ddd;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
   height: 100vh;
   box-sizing: border-box;
   overflow-y: auto;
@@ -16,7 +16,7 @@
 .sidebar-section h3 {
   margin-bottom: 0.5rem;
   font-size: 0.95rem;
-  color: #555;
+  color: var(--muted);
 }
 
 .sidebar-item {
@@ -28,10 +28,11 @@
 }
 
 .sidebar-item:hover {
-  background-color: #333;
+  background-color: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
 .sidebar-item.active {
-  background-color: #555;
+  background-color: var(--accent);
+  color: var(--bg);
   font-weight: bold;
 }

--- a/frontend/src/SynthesisDoc.css
+++ b/frontend/src/SynthesisDoc.css
@@ -7,8 +7,8 @@
   font-size: 17px;
   line-height: 1.68;
   letter-spacing: -0.01em;
-  color: #e1e1e1;
-  background: #0d0d0d;
+  color: var(--text);
+  background: var(--bg);
 }
 
 /* section dividers via white-space only */
@@ -19,7 +19,7 @@
 /* transcript speaker labels */
 .transcript p strong {
   font-weight: 600;
-  color: #ffffff;
+  color: var(--text);
 }
 
 .transcript p + p {
@@ -39,7 +39,7 @@
 .annotated-unit aside {
   font-size: 0.78em;
   line-height: 1.4;
-  color: #7c7c7c;
+  color: var(--muted);
   margin-top: 0.45rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;

--- a/frontend/src/ThemesStage.css
+++ b/frontend/src/ThemesStage.css
@@ -37,10 +37,10 @@
 
 .atom-card {
   font-size: 0.95rem;
-  background: #181818;
+  background: var(--surface);
   border-radius: 6px;
   padding: 0.75rem;
-  color: #ddd;
+  color: var(--text);
   line-height: 1.5;
 }
 

--- a/frontend/src/TranscriptStage.css
+++ b/frontend/src/TranscriptStage.css
@@ -329,8 +329,8 @@
 }
 
 .delete-comment:hover {
-  background: rgba(255, 0, 0, 0.1);
-  color: #ff6b6b;
+  background: color-mix(in srgb, var(--error) 10%, transparent);
+  color: var(--error);
 }
 
 /* Empty State */

--- a/frontend/src/UploadStage.css
+++ b/frontend/src/UploadStage.css
@@ -14,13 +14,13 @@
   font-size: 2rem;
   margin-bottom: 0.5rem;
   font-weight: 600;
-  color: #ffffff;
+  color: var(--text);
 }
 
 .upload-box p {
   font-size: 1rem;
   margin-bottom: 2rem;
-  color: #a1a1a1;
+  color: var(--muted);
 }
 
 /* Visually hidden but accessible */
@@ -49,7 +49,7 @@
   padding: 3rem 2rem;
   border: 2px dashed var(--border);
   border-radius: var(--radius);
-  background-color: rgba(255, 255, 255, 0.03);
+  background-color: color-mix(in srgb, var(--text) 3%, transparent);
   color: var(--muted);
   transition: all 0.2s ease;
   cursor: pointer;
@@ -60,8 +60,8 @@
 .upload-area:not(.disabled):hover,
 .upload-area:focus-within {
   border-color: var(--accent);
-  background-color: rgba(255, 255, 255, 0.05);
-  box-shadow: 0 0 0 2px rgba(var(--accent-rgb), 0.1);
+  background-color: color-mix(in srgb, var(--text) 5%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
 .upload-area.disabled {
@@ -91,7 +91,7 @@
 /* Drag active state */
 .upload-area.drag-active {
   border-color: var(--accent);
-  background-color: rgba(var(--accent-rgb), 0.05);
+  background-color: color-mix(in srgb, var(--accent) 5%, transparent);
 }
 
 input[type="file"] {
@@ -110,7 +110,7 @@ input[type="file"] {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: transparent;
-  color: #ffffff;
+  color: var(--text);
   margin-top: 1rem;
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -29,11 +29,11 @@ body {
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--accent);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--accent);
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- replace hex literals across pipeline stages with theme variables
- normalize backgrounds, text and borders to new dark theme tokens

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run lint` *(fails: fetchWithProject/setStatusMessage not defined)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6893d3731dac832caad410b1c690bcb2