### PR TITLE
Rename Mother2 references to slugg.e

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,3 +1,3 @@
-# Mother2 Backend
+# slugg.e Backend
 
-Backend service for the Mother2 research synthesis application.
+Backend service for the slugg.e research synthesis application.

--- a/backend/board_creator.py
+++ b/backend/board_creator.py
@@ -1,5 +1,5 @@
 """
-Tldraw-based Collaborative Board Creator for Mother-2
+Tldraw-based Collaborative Board Creator for slugg.e
 Real-time collaborative whiteboard with journey mapping and theme visualization
 """
 

--- a/backend/chat_assistant.py
+++ b/backend/chat_assistant.py
@@ -1,5 +1,5 @@
 """
-LLM Chat Assistant for Mother-2
+LLM Chat Assistant for slugg.e
 Interactive AI assistant providing guidance throughout the research synthesis process
 """
 
@@ -299,7 +299,7 @@ class ChatAssistant:
     def _clarify_methodology_response(self, message: str) -> Dict[str, Any]:
         """Explain methodology and process"""
         
-        response = """The Mother-2 system uses a systematic approach to identify themes from research transcripts:
+        response = """The slugg.e system uses a systematic approach to identify themes from research transcripts:
 
 1. **Atomization**: Break transcripts into atomic units (quotes, statements)
 2. **Annotation**: Tag atoms with metadata (speaker, context, sentiment)

--- a/backend/human_checkpoints.py
+++ b/backend/human_checkpoints.py
@@ -1,5 +1,5 @@
 """
-Human Checkpoint System for Mother-2
+Human Checkpoint System for slugg.e
 Interactive QA system for human-in-the-loop validation
 """
 

--- a/backend/normalizer.py
+++ b/backend/normalizer.py
@@ -1,5 +1,5 @@
 """
-Enhanced Normalizer for Mother-2
+Enhanced Normalizer for slugg.e
 Advanced transcript cleaning with speaker labeling and PII detection
 """
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "mother2-backend"
+name = "slugg.e-backend"
 version = "0.1.0"
 description = ""
 authors = [

--- a/backend/quality_guard.py
+++ b/backend/quality_guard.py
@@ -1,5 +1,5 @@
 """
-Quality Guard System for Mother-2
+Quality Guard System for slugg.e
 Final validation system ensuring research quality and evidence standards
 """
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
-# React + Vite
+# slugg.e Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Frontend for the slugg.e research synthesis application built with React and Vite.
 
 Currently, two official plugins are available:
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>slugg.e</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Rebrand docs and comments from Mother2 to slugg.e
- Rename frontend page title and README to slugg.e
- Update backend config and helper messages to the new name

## Testing
- `python -m pytest`
- `npm run lint` *(fails: 'fetchWithProject' is not defined, 'projectSlug' is not defined, 'setStatusMessage' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6893d3720d5c832cac8d2cc5925be6c4