### PR TITLE
Return board data and URL from board creation

### DIFF
--- a/backend/board_creator.py
+++ b/backend/board_creator.py
@@ -6,7 +6,7 @@ Real-time collaborative whiteboard with journey mapping and theme visualization
 import json
 import uuid
 from datetime import datetime
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Tuple
 from dataclasses import dataclass, asdict
 from pathlib import Path
 from paths import get_stage_path
@@ -94,8 +94,8 @@ class BoardCreator:
             self.ydoc = None
             self.board_state = None
         
-    async def create_board(self, themes: List[Dict], atoms: List[Dict], 
-                          journey_data: Dict, insights: List[Dict]) -> str:
+    async def create_board(self, themes: List[Dict], atoms: List[Dict],
+                          journey_data: Dict, insights: List[Dict]) -> Tuple[Dict[str, Any], Optional[str]]:
         """
         Create a comprehensive research synthesis board
         
@@ -156,8 +156,9 @@ class BoardCreator:
         # Initialize Yjs document for real-time collaboration if available
         if self.ydoc:
             self._initialize_yjs_board(board_data)
-        
-        return board_id
+
+        board_url = self.get_board_url(board_id)
+        return board_data, board_url
     
     def _create_journey_map(self, journey_data: Dict) -> Dict[str, Any]:
         """Create journey map elements"""
@@ -505,16 +506,17 @@ class BoardCreator:
             return str(board_file)
 
 # Example usage
-async def create_research_board(project_slug: str, themes: List[Dict], 
-                               atoms: List[Dict], journey_data: Dict, 
-                               insights: List[Dict]) -> str:
+async def create_research_board(project_slug: str, themes: List[Dict],
+                               atoms: List[Dict], journey_data: Dict,
+                               insights: List[Dict]) -> Dict[str, Any]:
     """Create a complete research synthesis board"""
     
     creator = BoardCreator(project_slug)
-    board_id = await creator.create_board(themes, atoms, journey_data, insights)
-    
+    board_data, board_url = await creator.create_board(themes, atoms, journey_data, insights)
+    board_id = board_data.get('id')
+
     return {
         'board_id': board_id,
-        'board_url': creator.get_board_url(board_id),
+        'board_url': board_url,
         'export_url': f"/api/export/{board_id}"
     }

--- a/backend/routes/board.py
+++ b/backend/routes/board.py
@@ -24,17 +24,20 @@ async def create_board(
     project_slug: str = Query(..., description="Project identifier"),
 ):
     """Create a collaborative board for the given project.
-    Returns the board ID that the frontend can load.
+    Returns the board data and an optional URL for collaborative access.
     """
     try:
         creator = BoardCreator(project_slug)
-        board_id = await creator.create_board(
+        board_data, board_url = await creator.create_board(
             payload.themes,
             payload.atoms,
             payload.journey_data,
             payload.insights,
         )
-        return {"board_id": board_id}
+        response = {"board": board_data}
+        if board_url:
+            response["board_url"] = board_url
+        return response
     except Exception as e:
         logger.exception("Board creation failed for project %s: %s", project_slug, e)
         raise HTTPException(status_code=500, detail=str(e))

--- a/frontend/src/ComprehensiveShell.jsx
+++ b/frontend/src/ComprehensiveShell.jsx
@@ -223,8 +223,10 @@ export default function ComprehensiveShell() {
           throw new Error(`Board creation failed (${boardRes.status}): ${errorText}`);
         }
         
-        const board = await boardRes.json();
+        const boardResponse = await boardRes.json();
         console.log('Board created successfully');
+
+        const board = { ...boardResponse.board, board_url: boardResponse.board_url };
 
         // Add to processed files
         const fileData = {


### PR DESCRIPTION
## Summary
- Return board JSON and URL from `BoardCreator.create_board`.
- Expose full board payload via `/board` endpoint.
- Store board details and URL in `ComprehensiveShell` for `BoardStage`.

## Testing
- `pytest` (no tests found)
- `npm test` (missing script)
- `npm run lint` (reports existing errors)


------
https://chatgpt.com/codex/tasks/task_e_6893d36e8f8c832cac5d0797ab26fd9e