### PR TITLE
refactor: use project-aware fetch helpers

### DIFF
--- a/frontend/src/ChatAssistantStage.jsx
+++ b/frontend/src/ChatAssistantStage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useGlobalStore } from "./store";
+import { fetchWithProject } from "./api";
 import "./ChatAssistantStage.css";
 
 export default function ChatAssistantStage({ file }) {
@@ -28,8 +29,10 @@ export default function ChatAssistantStage({ file }) {
     if (!projectSlug) return;
 
     try {
-      const response = await fetch(
-        `http://localhost:8000/chat/history?project_slug=${encodeURIComponent(projectSlug)}`
+      const response = await fetchWithProject(
+        '/chat/history',
+        {},
+        projectSlug
       );
 
       if (response.ok) {

--- a/frontend/src/QualityGuardStage.jsx
+++ b/frontend/src/QualityGuardStage.jsx
@@ -26,9 +26,10 @@ export default function QualityGuardStage({ file }) {
     setError(null);
 
     try {
-      const response = await fetch(
-        `http://localhost:8000/quality-guard?filename=${encodeURIComponent(file.name)}&project_slug=${encodeURIComponent(projectSlug)}`,
-        { method: "POST" }
+      const response = await fetchWithProject(
+        '/quality-guard?filename=' + encodeURIComponent(file.name),
+        { method: 'POST' },
+        projectSlug
       );
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- replace direct fetch in QualityGuardStage with fetchWithProject
- switch GraphStage and ChatAssistantStage to fetchWithProject to remove hard-coded localhost API references

## Testing
- `npm test` (fails: Missing script "test")
- `npx eslint src/QualityGuardStage.jsx src/GraphStage.jsx src/ChatAssistantStage.jsx` (warnings only)
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_6893d36e07d8832cbc3d67ea92491473