### PR TITLE
Use project-aware API for chat history

### DIFF
--- a/frontend/src/ChatAssistantStage.jsx
+++ b/frontend/src/ChatAssistantStage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useGlobalStore } from "./store";
+import { fetchWithProject } from "./api";
 import "./ChatAssistantStage.css";
 
 export default function ChatAssistantStage({ file }) {
@@ -28,8 +29,10 @@ export default function ChatAssistantStage({ file }) {
     if (!projectSlug) return;
 
     try {
-      const response = await fetch(
-        `http://localhost:8000/chat/history?project_slug=${encodeURIComponent(projectSlug)}`
+      const response = await fetchWithProject(
+        "/chat/history",
+        {},
+        projectSlug
       );
 
       if (response.ok) {


### PR DESCRIPTION
## Summary
- import `fetchWithProject` helper into chat assistant
- load conversation history through project-aware API endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 11 problems in other files)*
- `npx eslint src/ChatAssistantStage.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6893d36ce84c832ca2df1b531c6af710