### PR TITLE
Add QA endpoints for human checkpoints

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4,7 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from paths import ensure_dirs
-from routes import upload, atoms, graph, comments, quality_guard, chat, board
+from routes import upload, atoms, graph, comments, quality_guard, chat, board, qa
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -43,3 +43,4 @@ app.include_router(comments.router)
 app.include_router(quality_guard.router)
 app.include_router(chat.router)
 app.include_router(board.router)
+app.include_router(qa.router)

--- a/backend/routes/qa.py
+++ b/backend/routes/qa.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from human_checkpoints import HumanCheckpointManager, ClarifyingQuestion
+
+router = APIRouter()
+
+
+def _serialize_question(question: ClarifyingQuestion) -> dict:
+    """Convert a ClarifyingQuestion to a JSON-serializable dict."""
+    return {
+        "question_id": question.question_id,
+        "checkpoint_type": question.checkpoint_type.value,
+        "context": question.context,
+        "question": question.question,
+        "options": question.options,
+        "current_answer": question.current_answer,
+        "confidence_score": question.confidence_score,
+        "created_at": question.created_at.isoformat() if question.created_at else None,
+        "answered_at": question.answered_at.isoformat() if question.answered_at else None,
+    }
+
+
+@router.get("/qa")
+async def get_questions(project_slug: str = Query(...), filename: str | None = Query(None)):
+    """Return all pending clarifying questions for a project."""
+    manager = HumanCheckpointManager(project_slug)
+    pending = manager.get_pending_questions()
+    return {"questions": [_serialize_question(q) for q in pending]}
+
+
+@router.post("/qa/answer")
+async def answer_question(request: Request, project_slug: str = Query(...)):
+    """Record an answer for a clarifying question."""
+    data = await request.json()
+    question_id = data.get("question_id")
+    answer = data.get("answer")
+    if not question_id or answer is None:
+        raise HTTPException(status_code=400, detail="question_id and answer required")
+
+    manager = HumanCheckpointManager(project_slug)
+    if not any(q.question_id == question_id for q in manager.questions):
+        raise HTTPException(status_code=404, detail="question not found")
+
+    manager.answer_question(question_id, answer)
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add `/qa` and `/qa/answer` endpoints using `HumanCheckpointManager`
- include QA router in FastAPI app

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893d36a793c832c84113e5ec0e8e6e1