### PR TITLE
refactor: define loadConversationHistory before effect

### DIFF
--- a/frontend/src/ChatAssistantStage.jsx
+++ b/frontend/src/ChatAssistantStage.jsx
@@ -18,13 +18,6 @@ export default function ChatAssistantStage({ file }) {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  // Load conversation history
-  useEffect(() => {
-    if (projectSlug) {
-      loadConversationHistory();
-    }
-  }, [projectSlug, loadConversationHistory]);
-
   const loadConversationHistory = useCallback(async () => {
     if (!projectSlug) return;
 
@@ -56,6 +49,13 @@ export default function ChatAssistantStage({ file }) {
       console.error("Failed to load conversation history:", err);
     }
   }, [projectSlug]);
+
+  // Load conversation history
+  useEffect(() => {
+    if (projectSlug) {
+      loadConversationHistory();
+    }
+  }, [projectSlug, loadConversationHistory]);
 
   async function sendMessage() {
     if (!inputMessage.trim() || !projectSlug) return;


### PR DESCRIPTION
## Summary
- Move loadConversationHistory hook above the effect that calls it in ChatAssistantStage.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 9 problems (6 errors, 3 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_6893f3be28d4832c905e2ae056ce89e2