### PR TITLE
Fix Supabase upsert execution in board creator

### DIFF
--- a/backend/board_creator.py
+++ b/backend/board_creator.py
@@ -469,7 +469,7 @@ class BoardCreator:
                 'board_data': board_data,
                 'created_at': board_data['created_at'],
                 'updated_at': board_data['updated_at']
-            })
+            }).execute()
         except Exception as e:
             print(f"Error saving to Supabase: {e}")
     


### PR DESCRIPTION
## Summary
- ensure board creator upserts execute against Supabase

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893f3bbe6e0832ca7e8f806af585724