### PR TITLE
Add spaCy dependency to backend

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "google-generativeai (>=0.8.5,<0.9.0)",
     "python-dotenv (>=1.1.1,<2.0.0)",
     "supabase (>=2.0.0,<3.0.0)",
-    "y-py (>=0.6.0,<1.0.0)"
+    "y-py (>=0.6.0,<1.0.0)",
+    "spacy (>=3.0,<4.0)"
 ]
 
 


### PR DESCRIPTION
## Summary
- add spaCy library to backend's project dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893f3b8b700832cb1f7072933e73e2c